### PR TITLE
Upgrade SZD dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "implementation/rocksdb/third-party/SimpleZNSDevice"]
+	path = implementation/rocksdb/third-party/SimpleZNSDevice
+	url = https://github.com/Krien/SimpleZNSDevice

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "dependencies/SimpleZNSDevice"]
-	path = dependencies/SimpleZNSDevice
-	url = https://github.com/Krien/SimpleZNSDevice

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The project exists out of two subprojects, both are available in `implementation
 
 ```bash
 git submodule update --init --recursive # Retrieve SZD, SPDK and DPDK
-cp -r ./dependencies/SimpleZNSDevice ./implementation/rocksdb/third-party
 cd  implementation/rocksdb
 pushd .
 cd third-party/SimpleZNSDevice/dependencies/spdk

--- a/implementation/rocksdb/CMakeLists.txt
+++ b/implementation/rocksdb/CMakeLists.txt
@@ -76,7 +76,7 @@ if(WITH_WINDOWS_UTF8_FILENAMES)
   add_definitions(-DROCKSDB_WINDOWS_UTF8_FILENAMES)
 endif()
 
-option(ZNS_PLUGIN "allow the ZNS pluging" ON)
+option(ZNS_PLUGIN "allow the ZNS plugin" ON)
 
 if(ZNS_PLUGIN)
   add_definitions(-DZNS_PLUGIN_ENABLED)

--- a/implementation/rocksdb/db/zns_impl/table/ln_zns_sstable.cc
+++ b/implementation/rocksdb/db/zns_impl/table/ln_zns_sstable.cc
@@ -166,7 +166,7 @@ Status LNZnsSSTable::InvalidateSSZone(const SSZoneMetaData& meta) {
     }
     ptrs.push_back(std::make_pair(from / zone_cap_, blocks / zone_cap_));
   }
-  return FromStatus(log_.Reset(ptrs));
+  return FromStatus(log_.Reset(ptrs, 1));
 }
 
 Iterator* LNZnsSSTable::NewIterator(const SSZoneMetaData& meta,


### PR DESCRIPTION
SZD has been upgraded, breaking the current API. Therefore, we update TropoDB to allow using the new version.
We also update the SZD submodule to immediately move to `implementation/third-party/...` instead of requiring a manual copy.