### PR TITLE
Performance counters for background operations

### DIFF
--- a/implementation/rocksdb/CMakeLists.txt
+++ b/implementation/rocksdb/CMakeLists.txt
@@ -1136,6 +1136,7 @@ set(ZNS_LSM_SOURCES
   db/zns_impl/index/zns_compaction.cc
   db/zns_impl/db_impl_zns.cc
   db/zns_impl/db_impl_zns_background.cc
+  db/zns_impl/db_impl_zns_diagnostics.cc
   db/zns_impl/db_impl_zns_not_supported.cc
 )
 

--- a/implementation/rocksdb/CMakeLists.txt
+++ b/implementation/rocksdb/CMakeLists.txt
@@ -1680,11 +1680,16 @@ else(DEFINED ENV{CLANG_FORMAT_PATH})
   message("Clang-format path: ${CLANG_FORMAT_PATH}")
 endif()
 
+set(FORMAT_PATHS "")
+foreach(PATH ${ZNS_LSM_SOURCES})
+  list(APPEND FORMAT_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/${PATH}")
+endforeach()
+
 add_custom_target(
-  format_rocksdb
+  format_rocksdb_zns
   COMMAND ${CLANG_FORMAT_PATH}
   -i
-  ${ZNS_LSM_SOURCES}
-  "./db/db_impl_switcher/*"
   "-style=file"
+  ${FORMAT_PATHS}
+  COMMENT "Formatting files"
 )

--- a/implementation/rocksdb/db/zns_impl/db_impl_zns.cc
+++ b/implementation/rocksdb/db/zns_impl/db_impl_zns.cc
@@ -77,8 +77,7 @@ DBImplZNS::DBImplZNS(const DBOptions& options, const std::string& dbname,
       bg_error_(Status::OK()),
       forced_schedule_(false),
       // diag
-      clock_(SystemClock::Default().get())
-      {
+      clock_(SystemClock::Default().get()) {
   for (size_t i = 0; i < ZnsConfig::lower_concurrency; i++) {
     wal_man_[i] = nullptr;
     wal_[i] = nullptr;

--- a/implementation/rocksdb/db/zns_impl/db_impl_zns.h
+++ b/implementation/rocksdb/db/zns_impl/db_impl_zns.h
@@ -76,7 +76,7 @@ class DBImplZNS : public DB {
   DBImplZNS(const DBImplZNS&) = delete;
   DBImplZNS& operator=(const DBImplZNS&) = delete;
 
-  void IODiagnostics();
+  void PrintStats();
   ~DBImplZNS() override;
 
   static Status ValidateOptions(const DBOptions& db_options);
@@ -336,6 +336,11 @@ class DBImplZNS : public DB {
 
   WriteBatch* BuildBatchGroup(Writer** last_writer, uint8_t parallel_number);
 
+  void PrintCompactionStats();
+  void PrintSSTableStats();
+  void PrintWALStats();
+  void PrintIODistrStats();
+
   // Should remain constant after construction
   const DBOptions options_;
   const std::string name_;
@@ -380,6 +385,11 @@ class DBImplZNS : public DB {
 
   // diagnostics
   SystemClock* const clock_;
+  bool print_compaction_stats_{true};
+  bool print_ss_stats_{false};
+  bool print_wal_stats_{false};
+  bool print_io_stats_{false};
+  bool print_io_heat_stats_{false};
   // diag flush
   TimingCounter flush_total_counter_;
   TimingCounter flush_flush_memtable_counter_;
@@ -399,7 +409,6 @@ class DBImplZNS : public DB {
   TimingCounter compaction_compaction_LN_;
   TimingCounter compaction_compaction_trivial_LN_;
   TimingCounter compaction_version_edit_LN_;
-
 };
 
 struct FlushData {

--- a/implementation/rocksdb/db/zns_impl/db_impl_zns.h
+++ b/implementation/rocksdb/db/zns_impl/db_impl_zns.h
@@ -387,7 +387,7 @@ class DBImplZNS : public DB {
   SystemClock* const clock_;
   bool print_compaction_stats_{true};
   bool print_ss_stats_{false};
-  bool print_wal_stats_{false};
+  bool print_wal_stats_{true};
   bool print_io_stats_{false};
   bool print_io_heat_stats_{false};
   // diag flush

--- a/implementation/rocksdb/db/zns_impl/db_impl_zns.h
+++ b/implementation/rocksdb/db/zns_impl/db_impl_zns.h
@@ -379,8 +379,27 @@ class DBImplZNS : public DB {
   std::array<size_t, ZnsConfig::lower_concurrency> wal_reserved_;
 
   // diagnostics
-  uint64_t flushes_;
+  SystemClock* const clock_;
+  // diag flush
+  TimingCounter flush_total_counter_;
+  TimingCounter flush_flush_memtable_counter_;
+  TimingCounter flush_update_version_counter_;
+  TimingCounter flush_reset_wal_counter_;
+  // diag compaction
   std::array<uint64_t, ZnsConfig::level_count - 1> compactions_;
+  TimingCounter compaction_compaction_L0_total_;
+  TimingCounter compaction_reset_L0_counter_;
+  TimingCounter compaction_pick_compaction_;
+  TimingCounter compaction_compaction_;
+  TimingCounter compaction_compaction_trivial_;
+  TimingCounter compaction_version_edit_;
+  TimingCounter compaction_compaction_LN_total_;
+  TimingCounter compaction_reset_LN_counter_;
+  TimingCounter compaction_pick_compaction_LN_;
+  TimingCounter compaction_compaction_LN_;
+  TimingCounter compaction_compaction_trivial_LN_;
+  TimingCounter compaction_version_edit_LN_;
+
 };
 
 struct FlushData {

--- a/implementation/rocksdb/db/zns_impl/db_impl_zns_diagnostics.cc
+++ b/implementation/rocksdb/db/zns_impl/db_impl_zns_diagnostics.cc
@@ -16,50 +16,47 @@
 #include "db/zns_impl/db_impl_zns.h"
 #include "db/zns_impl/diagnostics.h"
 
-
 namespace ROCKSDB_NAMESPACE {
 
 static void PrintPerfCounterHeader() {
-    std::string table_line(113, '-');
-    std::cout << table_line << "\n";
-    std::cout 
-        << std::left << std::setw(20) << "| name" 
-        << std::setw(15) << "| total (ops)" 
-        << std::setw(15) << "| sum (micros)" 
-        << std::setw(15) << "| min (micros)" 
-        << std::setw(15) << "| max (micros)" 
-        << std::setw(15) << "| avg (micros)" 
-        << std::setw(15) << "| StdDev (micros)" 
-        << "|\n";
-    std::cout << table_line << "\n";
+  std::string table_line(113, '-');
+  std::cout << table_line << "\n";
+  std::cout << std::left << std::setw(20) << "| name" << std::setw(15)
+            << "| total (ops)" << std::setw(15) << "| sum (micros)"
+            << std::setw(15) << "| min (micros)" << std::setw(15)
+            << "| max (micros)" << std::setw(15) << "| avg (micros)"
+            << std::setw(15) << "| StdDev (micros)"
+            << "|\n";
+  std::cout << table_line << "\n";
 }
 
-static void PrintPerfCounterRow(std::string name, const TimingCounter& counter) {
+static void PrintPerfCounterRow(std::string name,
+                                const TimingCounter& counter) {
   name = "| " + name;
-  std::cout 
-     << std::left << std::setw(20) << name 
-     << std::fixed << std::setprecision(0)
-     << std::left << "|" << std::right << std::setw(14) << counter.GetNum() 
-     << std::left << "|" << std::right << std::setw(14) << counter.GetSum()      
-     << std::left << "|" << std::right << std::setw(14) << counter.GetMin() 
-     << std::left << "|" << std::right << std::setw(14) << counter.GetMax() 
-     << std::fixed << std::setprecision(2)
-     << std::left << "|" << std::right << std::setw(14) << counter.GetAvg() 
-     << std::left << "|" << std::right << std::setw(14) << counter.GetStandardDeviation()
-     << "  |\n";
+  std::cout << std::left << std::setw(20) << name << std::fixed
+            << std::setprecision(0) << std::left << "|" << std::right
+            << std::setw(14) << counter.GetNum() << std::left << "|"
+            << std::right << std::setw(14) << counter.GetSum() << std::left
+            << "|" << std::right << std::setw(14) << counter.GetMin()
+            << std::left << "|" << std::right << std::setw(14)
+            << counter.GetMax() << std::fixed << std::setprecision(2)
+            << std::left << "|" << std::right << std::setw(14)
+            << counter.GetAvg() << std::left << "|" << std::right
+            << std::setw(14) << counter.GetStandardDeviation() << "  |\n";
 }
 
 static void PrintPerfCounterTail() {
-    std::string table_line(113, '-');
-    std::cout << table_line << "\n";
+  std::string table_line(113, '-');
+  std::cout << table_line << "\n";
 }
 
-static void PrintCounterTable(const std::vector<std::pair<std::string,const TimingCounter&>> counters) {
-    PrintPerfCounterHeader();
-    for (auto& counter : counters) {
-        PrintPerfCounterRow(counter.first, counter.second);
-    }
-    PrintPerfCounterTail();
+static void PrintCounterTable(
+    const std::vector<std::pair<std::string, const TimingCounter&>> counters) {
+  PrintPerfCounterHeader();
+  for (auto& counter : counters) {
+    PrintPerfCounterRow(counter.first, counter.second);
+  }
+  PrintPerfCounterTail();
 }
 
 void DBImplZNS::PrintCompactionStats() {
@@ -67,36 +64,31 @@ void DBImplZNS::PrintCompactionStats() {
   std::cout << "Flush count:\n\t" << flush_total_counter_.GetNum() << "\n";
   std::cout << "Compaction count:\n";
   for (uint8_t level = 0; level < ZnsConfig::level_count - 1; level++) {
-    std::cout << "\tCompaction to " << (level + 1) << ":" << compactions_[level] << "\n";
+    std::cout << "\tCompaction to " << (level + 1) << ":" << compactions_[level]
+              << "\n";
   }
 
   std::cout << "Flushes latency breakdown:\n";
-  PrintCounterTable({
-      {"Total", flush_total_counter_}
-      ,{"Writing L0", flush_flush_memtable_counter_}
-      ,{"Updating Version", flush_update_version_counter_}
-      ,{"Resetting WALs", flush_reset_wal_counter_}
-  });
+  PrintCounterTable({{"Total", flush_total_counter_},
+                     {"Writing L0", flush_flush_memtable_counter_},
+                     {"Updating Version", flush_update_version_counter_},
+                     {"Resetting WALs", flush_reset_wal_counter_}});
 
   std::cout << "L0 compaction latency breakdown:\n";
-  PrintCounterTable({
-      {"Total", compaction_compaction_L0_total_}
-      ,{"Picking SSTables", compaction_pick_compaction_}
-      ,{"Writing LN", compaction_compaction_}
-      ,{"Copying L0", compaction_compaction_trivial_}
-      ,{"Updating version",compaction_version_edit_}
-      ,{"Resetting L0",compaction_reset_L0_counter_}
-  });
+  PrintCounterTable({{"Total", compaction_compaction_L0_total_},
+                     {"Picking SSTables", compaction_pick_compaction_},
+                     {"Writing LN", compaction_compaction_},
+                     {"Copying L0", compaction_compaction_trivial_},
+                     {"Updating version", compaction_version_edit_},
+                     {"Resetting L0", compaction_reset_L0_counter_}});
 
   std::cout << "LN compaction latency breakdown:\n";
-  PrintCounterTable({
-      {"Total", compaction_compaction_LN_total_}
-      ,{"Picking SSTables", compaction_pick_compaction_LN_}
-      ,{"Writing LN", compaction_compaction_LN_}
-      ,{"Copying LN", compaction_compaction_trivial_LN_}
-      ,{"Updating version",compaction_version_edit_LN_}
-      ,{"Resetting LN",compaction_reset_LN_counter_}
-  });
+  PrintCounterTable({{"Total", compaction_compaction_LN_total_},
+                     {"Picking SSTables", compaction_pick_compaction_LN_},
+                     {"Writing LN", compaction_compaction_LN_},
+                     {"Copying LN", compaction_compaction_trivial_LN_},
+                     {"Updating version", compaction_version_edit_LN_},
+                     {"Resetting LN", compaction_reset_LN_counter_}});
 }
 
 void DBImplZNS::PrintSSTableStats() {
@@ -108,10 +100,11 @@ void DBImplZNS::PrintWALStats() {
   std::cout << "====  WAL stats ====\n";
   for (size_t i = 0; i < ZnsConfig::lower_concurrency; i++) {
     std::cout << "====  WAL manager " << i << " ====\n";
-    std::vector<std::pair<std::string, const TimingCounter>> wal_stats = wal_man_[i]->GetAdditionalWALStatistics();
+    std::vector<std::pair<std::string, const TimingCounter>> wal_stats =
+        wal_man_[i]->GetAdditionalWALStatistics();
     std::vector<std::pair<std::string, const TimingCounter&>> wal_stats_ref;
     for (auto& p : wal_stats) {
-        wal_stats_ref.push_back({p.first, p.second});
+      wal_stats_ref.push_back({p.first, p.second});
     }
     PrintCounterTable(wal_stats_ref);
   }
@@ -140,11 +133,10 @@ static void AddToJSONHotZoneStream(const ZNSDiagnostics& diag,
 void DBImplZNS::PrintIODistrStats() {
   std::cout << "==== raw IO metrics ==== \n";
   std::cout << std::left << std::setw(10) << "Metric " << std::right
-            << std::setw(15) << "Append (ops)" 
-            << std::setw(25) << "Written (Bytes)" 
-            << std::setw(15) << "Read (ops)"
-            << std::setw(25) << "Read (Bytes)" 
-            << std::setw(16) << "Reset (zones)"
+            << std::setw(15) << "Append (ops)" << std::setw(25)
+            << "Written (Bytes)" << std::setw(15) << "Read (ops)"
+            << std::setw(25) << "Read (Bytes)" << std::setw(16)
+            << "Reset (zones)"
             << "\n";
   std::cout << std::setfill('-') << std::setw(107) << "\n" << std::setfill(' ');
   struct ZNSDiagnostics totaldiag = {.name_ = "Total",
@@ -205,16 +197,16 @@ void DBImplZNS::PrintIODistrStats() {
 
 void DBImplZNS::PrintStats() {
   if (print_compaction_stats_) {
-       PrintCompactionStats();
+    PrintCompactionStats();
   }
   if (print_ss_stats_) {
-      PrintSSTableStats();
+    PrintSSTableStats();
   }
   if (print_wal_stats_) {
     PrintWALStats();
   }
   if (print_io_stats_) {
-      PrintIODistrStats();
+    PrintIODistrStats();
   }
 }
-}
+}  // namespace ROCKSDB_NAMESPACE

--- a/implementation/rocksdb/db/zns_impl/db_impl_zns_diagnostics.cc
+++ b/implementation/rocksdb/db/zns_impl/db_impl_zns_diagnostics.cc
@@ -20,11 +20,12 @@
 namespace ROCKSDB_NAMESPACE {
 
 static void PrintPerfCounterHeader() {
-    std::string table_line(98, '-');
+    std::string table_line(113, '-');
     std::cout << table_line << "\n";
     std::cout 
         << std::left << std::setw(20) << "| name" 
         << std::setw(15) << "| total (ops)" 
+        << std::setw(15) << "| sum (micros)" 
         << std::setw(15) << "| min (micros)" 
         << std::setw(15) << "| max (micros)" 
         << std::setw(15) << "| avg (micros)" 
@@ -37,16 +38,19 @@ static void PrintPerfCounterRow(std::string name, const TimingCounter& counter) 
   name = "| " + name;
   std::cout 
      << std::left << std::setw(20) << name 
+     << std::fixed << std::setprecision(0)
      << std::left << "|" << std::right << std::setw(14) << counter.GetNum() 
+     << std::left << "|" << std::right << std::setw(14) << counter.GetSum()      
      << std::left << "|" << std::right << std::setw(14) << counter.GetMin() 
      << std::left << "|" << std::right << std::setw(14) << counter.GetMax() 
+     << std::fixed << std::setprecision(2)
      << std::left << "|" << std::right << std::setw(14) << counter.GetAvg() 
      << std::left << "|" << std::right << std::setw(14) << counter.GetStandardDeviation()
      << "  |\n";
 }
 
 static void PrintPerfCounterTail() {
-    std::string table_line(98, '-');
+    std::string table_line(113, '-');
     std::cout << table_line << "\n";
 }
 
@@ -103,7 +107,13 @@ void DBImplZNS::PrintSSTableStats() {
 void DBImplZNS::PrintWALStats() {
   std::cout << "====  WAL stats ====\n";
   for (size_t i = 0; i < ZnsConfig::lower_concurrency; i++) {
-    wal_man_[i]->PrintAdditionalWALStatistics();
+    std::cout << "====  WAL manager " << i << " ====\n";
+    std::vector<std::pair<std::string, const TimingCounter>> wal_stats = wal_man_[i]->GetAdditionalWALStatistics();
+    std::vector<std::pair<std::string, const TimingCounter&>> wal_stats_ref;
+    for (auto& p : wal_stats) {
+        wal_stats_ref.push_back({p.first, p.second});
+    }
+    PrintCounterTable(wal_stats_ref);
   }
 }
 

--- a/implementation/rocksdb/db/zns_impl/db_impl_zns_diagnostics.cc
+++ b/implementation/rocksdb/db/zns_impl/db_impl_zns_diagnostics.cc
@@ -1,0 +1,210 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <numeric>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "db/zns_impl/config.h"
+#include "db/zns_impl/db_impl_zns.h"
+#include "db/zns_impl/diagnostics.h"
+
+
+namespace ROCKSDB_NAMESPACE {
+
+static void PrintPerfCounterHeader() {
+    std::string table_line(98, '-');
+    std::cout << table_line << "\n";
+    std::cout 
+        << std::left << std::setw(20) << "| name" 
+        << std::setw(15) << "| total (ops)" 
+        << std::setw(15) << "| min (micros)" 
+        << std::setw(15) << "| max (micros)" 
+        << std::setw(15) << "| avg (micros)" 
+        << std::setw(15) << "| StdDev (micros)" 
+        << "|\n";
+    std::cout << table_line << "\n";
+}
+
+static void PrintPerfCounterRow(std::string name, const TimingCounter& counter) {
+  name = "| " + name;
+  std::cout 
+     << std::left << std::setw(20) << name 
+     << std::left << "|" << std::right << std::setw(14) << counter.GetNum() 
+     << std::left << "|" << std::right << std::setw(14) << counter.GetMin() 
+     << std::left << "|" << std::right << std::setw(14) << counter.GetMax() 
+     << std::left << "|" << std::right << std::setw(14) << counter.GetAvg() 
+     << std::left << "|" << std::right << std::setw(14) << counter.GetStandardDeviation()
+     << "  |\n";
+}
+
+static void PrintPerfCounterTail() {
+    std::string table_line(98, '-');
+    std::cout << table_line << "\n";
+}
+
+static void PrintCounterTable(const std::vector<std::pair<std::string,const TimingCounter&>> counters) {
+    PrintPerfCounterHeader();
+    for (auto& counter : counters) {
+        PrintPerfCounterRow(counter.first, counter.second);
+    }
+    PrintPerfCounterTail();
+}
+
+void DBImplZNS::PrintCompactionStats() {
+  std::cout << "==== Background operation ====\n";
+  std::cout << "Flush count:\n\t" << flush_total_counter_.GetNum() << "\n";
+  std::cout << "Compaction count:\n";
+  for (uint8_t level = 0; level < ZnsConfig::level_count - 1; level++) {
+    std::cout << "\tCompaction to " << (level + 1) << ":" << compactions_[level] << "\n";
+  }
+
+  std::cout << "Flushes latency breakdown:\n";
+  PrintCounterTable({
+      {"Total", flush_total_counter_}
+      ,{"Writing L0", flush_flush_memtable_counter_}
+      ,{"Updating Version", flush_update_version_counter_}
+      ,{"Resetting WALs", flush_reset_wal_counter_}
+  });
+
+  std::cout << "L0 compaction latency breakdown:\n";
+  PrintCounterTable({
+      {"Total", compaction_compaction_L0_total_}
+      ,{"Picking SSTables", compaction_pick_compaction_}
+      ,{"Writing LN", compaction_compaction_}
+      ,{"Copying L0", compaction_compaction_trivial_}
+      ,{"Updating version",compaction_version_edit_}
+      ,{"Resetting L0",compaction_reset_L0_counter_}
+  });
+
+  std::cout << "LN compaction latency breakdown:\n";
+  PrintCounterTable({
+      {"Total", compaction_compaction_LN_total_}
+      ,{"Picking SSTables", compaction_pick_compaction_LN_}
+      ,{"Writing LN", compaction_compaction_LN_}
+      ,{"Copying LN", compaction_compaction_trivial_LN_}
+      ,{"Updating version",compaction_version_edit_LN_}
+      ,{"Resetting LN",compaction_reset_LN_counter_}
+  });
+}
+
+void DBImplZNS::PrintSSTableStats() {
+  std::cout << "====  SSTable layout ====\n";
+  std::cout << versions_->DebugString();
+}
+
+void DBImplZNS::PrintWALStats() {
+  std::cout << "====  WAL stats ====\n";
+  for (size_t i = 0; i < ZnsConfig::lower_concurrency; i++) {
+    wal_man_[i]->PrintAdditionalWALStatistics();
+  }
+}
+
+static void PrintIOColumn(const ZNSDiagnostics& diag) {
+  std::cout << std::left << std::setw(10) << diag.name_ << std::right
+            << std::setw(15) << diag.append_operations_counter_ << std::setw(25)
+            << diag.bytes_written_ << std::setw(15)
+            << diag.read_operations_counter_ << std::setw(25)
+            << diag.bytes_read_ << std::setw(16) << diag.zones_erased_counter_
+            << "\n";
+}
+
+static void AddToJSONHotZoneStream(const ZNSDiagnostics& diag,
+                                   std::ostringstream& erased,
+                                   std::ostringstream& append) {
+  for (uint64_t r : diag.zones_erased_) {
+    erased << r << ",";
+  }
+  for (uint64_t a : diag.append_operations_) {
+    append << a << ",";
+  }
+}
+
+void DBImplZNS::PrintIODistrStats() {
+  std::cout << "==== raw IO metrics ==== \n";
+  std::cout << std::left << std::setw(10) << "Metric " << std::right
+            << std::setw(15) << "Append (ops)" 
+            << std::setw(25) << "Written (Bytes)" 
+            << std::setw(15) << "Read (ops)"
+            << std::setw(25) << "Read (Bytes)" 
+            << std::setw(16) << "Reset (zones)"
+            << "\n";
+  std::cout << std::setfill('-') << std::setw(107) << "\n" << std::setfill(' ');
+  struct ZNSDiagnostics totaldiag = {.name_ = "Total",
+                                     .bytes_written_ = 0,
+                                     .append_operations_counter_ = 0,
+                                     .bytes_read_ = 0,
+                                     .read_operations_counter_ = 0,
+                                     .zones_erased_counter_ = 0};
+  std::ostringstream hotzones_reset;
+  std::ostringstream hotzones_append;
+  hotzones_reset << "[";
+  hotzones_append << "[";
+  {
+    ZNSDiagnostics diag = manifest_->IODiagnostics();
+    PrintIOColumn(diag);
+    totaldiag.bytes_written_ += diag.bytes_written_;
+    totaldiag.append_operations_counter_ += diag.append_operations_counter_;
+    totaldiag.bytes_read_ += diag.bytes_read_;
+    totaldiag.read_operations_counter_ += diag.read_operations_counter_;
+    totaldiag.zones_erased_counter_ += diag.zones_erased_counter_;
+    AddToJSONHotZoneStream(diag, hotzones_reset, hotzones_append);
+  }
+  {
+    for (size_t i = 0; i < ZnsConfig::lower_concurrency; i++) {
+      std::vector<ZNSDiagnostics> diags = wal_man_[i]->IODiagnostics();
+      for (auto& diag : diags) {
+        diag.name_ += i;
+        PrintIOColumn(diag);
+        totaldiag.bytes_written_ += diag.bytes_written_;
+        totaldiag.append_operations_counter_ += diag.append_operations_counter_;
+        totaldiag.bytes_read_ += diag.bytes_read_;
+        totaldiag.read_operations_counter_ += diag.read_operations_counter_;
+        totaldiag.zones_erased_counter_ += diag.zones_erased_counter_;
+        AddToJSONHotZoneStream(diag, hotzones_reset, hotzones_append);
+      }
+    }
+  }
+  {
+    std::vector<ZNSDiagnostics> diags = ss_manager_->IODiagnostics();
+    for (auto& diag : diags) {
+      PrintIOColumn(diag);
+      totaldiag.bytes_written_ += diag.bytes_written_;
+      totaldiag.append_operations_counter_ += diag.append_operations_counter_;
+      totaldiag.bytes_read_ += diag.bytes_read_;
+      totaldiag.read_operations_counter_ += diag.read_operations_counter_;
+      totaldiag.zones_erased_counter_ += diag.zones_erased_counter_;
+      AddToJSONHotZoneStream(diag, hotzones_reset, hotzones_append);
+    }
+  }
+  PrintIOColumn(totaldiag);
+  std::cout << std::setfill('_') << std::setw(107) << "\n" << std::setfill(' ');
+  if (print_io_heat_stats_) {
+    std::cout << "=== Hot zones as a raw list === \n";
+    std::cout << hotzones_reset.str() << "]\n";
+    std::cout << hotzones_append.str() << "]\n";
+  }
+}
+
+void DBImplZNS::PrintStats() {
+  if (print_compaction_stats_) {
+       PrintCompactionStats();
+  }
+  if (print_ss_stats_) {
+      PrintSSTableStats();
+  }
+  if (print_wal_stats_) {
+    PrintWALStats();
+  }
+  if (print_io_stats_) {
+      PrintIODistrStats();
+  }
+}
+}

--- a/implementation/rocksdb/db/zns_impl/diagnostics.h
+++ b/implementation/rocksdb/db/zns_impl/diagnostics.h
@@ -38,12 +38,12 @@ struct TimingCounter {
     return num_;
   }
 
-  uint64_t GetMin() const {
-    return min_;
+  double GetMin() const {
+    return min_ == std::numeric_limits<uint64_t>::max() ? -1. : static_cast<double>(min_);
   }
 
-  uint64_t GetMax() const {
-    return max_;
+  double GetMax() const {
+    return max_ == 0 ? -1. : static_cast<double>(max_);
   }
 
   double GetAvg() const {

--- a/implementation/rocksdb/db/zns_impl/diagnostics.h
+++ b/implementation/rocksdb/db/zns_impl/diagnostics.h
@@ -22,6 +22,39 @@ struct TimingCounter {
   
   TimingCounter() : num_(0), sum_(0), sum_squared_(0), min_(std::numeric_limits<uint64_t>::max()), max_(0) {}
 
+  TimingCounter operator + (TimingCounter const &tc) {
+    TimingCounter tc_new;
+    tc_new.num_ = num_ + tc.num_;
+    tc_new.sum_ = sum_ + tc.sum_;
+    tc_new.sum_squared_ = sum_squared_ + tc.sum_squared_;
+    if (num_ == 0) {
+      tc_new.min_ = tc.min_;
+      tc_new.max_ = tc.max_;
+    } else if (tc.num_  == 0) {
+      tc_new.min_ = min_;
+      tc_new.max_ = max_;
+    } else {
+      tc_new.min_ = std::min(min_, tc.min_);
+      tc_new.max_ = std::max(max_, tc.max_);
+    }
+    return tc_new;
+  }
+
+  void operator += (TimingCounter const &tc) {
+    num_ += tc.num_;
+    sum_ += tc.sum_;
+    sum_squared_ += tc.sum_squared_;
+    if (num_ == 0) {
+      min_ = tc.min_;
+      max_ = tc.max_;
+    } else if (tc.num_  == 0) {
+      // nothing to do
+    } else {
+      min_ = std::min(min_, tc.min_);
+      max_ = std::max(max_, tc.max_);
+    }
+  }
+
   void AddTiming(uint64_t time) {
     if (time > max_) {
       max_ = time;
@@ -36,6 +69,10 @@ struct TimingCounter {
 
   uint64_t GetNum() const {
     return num_;
+  }
+
+  double GetSum() const {
+    return static_cast<double>(sum_);
   }
 
   double GetMin() const {

--- a/implementation/rocksdb/db/zns_impl/diagnostics.h
+++ b/implementation/rocksdb/db/zns_impl/diagnostics.h
@@ -4,11 +4,62 @@
 #define ZNS_DIAGNOSTICS_H
 
 #include <vector>
+#include <cmath>
+#include <limits>
 
 #include "rocksdb/rocksdb_namespace.h"
 #include "rocksdb/slice.h"
 
 namespace ROCKSDB_NAMESPACE {
+
+// NOT thread-safe
+struct TimingCounter {
+  uint64_t num_;
+  uint64_t sum_;
+  uint64_t sum_squared_;
+  uint64_t min_;
+  uint64_t max_;
+  
+  TimingCounter() : num_(0), sum_(0), sum_squared_(0), min_(std::numeric_limits<uint64_t>::max()), max_(0) {}
+
+  void AddTiming(uint64_t time) {
+    if (time > max_) {
+      max_ = time;
+    }
+    if (time < min_) {
+      min_ = time;
+    }
+    num_++;
+    sum_ += time;
+    sum_squared_ += time * time;
+  }
+
+  uint64_t GetNum() const {
+    return num_;
+  }
+
+  uint64_t GetMin() const {
+    return min_;
+  }
+
+  uint64_t GetMax() const {
+    return max_;
+  }
+
+  double GetAvg() const {
+    return num_ == 0 ? -1. : 
+      static_cast<double>(sum_) / static_cast<double>(num_);
+  }
+
+  double GetStandardDeviation() const {
+    // See util/histogram.cc from LevelDB. However, we use -1 for none, not 0.
+    return num_ == 0 ? -1. : 
+      std::sqrt(static_cast<double>(sum_squared_ * num_ - sum_ * sum_) /
+                static_cast<double>(num_ * num_));
+  }      
+};
+
+// NOT thread-safe
 struct ZNSDiagnostics {
   std::string name_;
   uint64_t bytes_written_;

--- a/implementation/rocksdb/db/zns_impl/persistence/zns_committer.cc
+++ b/implementation/rocksdb/db/zns_impl/persistence/zns_committer.cc
@@ -388,7 +388,7 @@ bool ZnsCommitter::SeekCommitReaderString(ZnsCommitReaderString& reader,
     }
     reader.commit_ptr +=
         ((length + kZnsHeaderSize + lba_size_ - 1) / lba_size_) * lba_size_;
-   // printf("Commit ptr %lu %lu \n", reader.commit_ptr, reader.commit_end);
+    // printf("Commit ptr %lu %lu \n", reader.commit_ptr, reader.commit_end);
     switch (type) {
       case ZnsRecordType::kFullType:
         reader.scratch.assign(header + kZnsHeaderSize, length);

--- a/implementation/rocksdb/db/zns_impl/persistence/zns_wal.cc
+++ b/implementation/rocksdb/db/zns_impl/persistence/zns_wal.cc
@@ -290,7 +290,6 @@ Status ZNSWAL::Reset() {
   return s;
 }
 
-
 Status ZNSWAL::Recover() {
   uint64_t before = clock_->NowMicros();
   Status s = FromStatus(log_.RecoverPointers());
@@ -300,7 +299,8 @@ Status ZNSWAL::Recover() {
 
 Status ZNSWAL::Replay(ZNSMemTable* mem, SequenceNumber* seq) {
   Status s = Status::OK();
-  // This check is also done in both replays, but ensures we do NOT measure it for perf!!
+  // This check is also done in both replays, but ensures we do NOT measure it
+  // for perf!!
   if (log_.Empty()) {
     return s;
   }

--- a/implementation/rocksdb/db/zns_impl/persistence/zns_wal.cc
+++ b/implementation/rocksdb/db/zns_impl/persistence/zns_wal.cc
@@ -108,11 +108,7 @@ Status ZNSWAL::DirectAppend(const Slice& data) {
   uint64_t before = clock_->NowMicros();
   Status s =
       FromStatus(log_.AsyncAppend(data.data(), data.size(), nullptr, true));
-  uint64_t value = clock_->NowMicros() - before;
-  num_ += 1;
-  sum_ += value;
-  sum_squares_ += value * value;
-  // printf("VAL %lu \n", value);
+  storage_append_perf_counter_.AddTiming(clock_->NowMicros() - before);
   return s;
 }
 
@@ -149,10 +145,7 @@ Status ZNSWAL::Append(const Slice& data, uint64_t seq) {
   }
 #endif
   delete[] out;
-  uint64_t value = clock_->NowMicros() - before;
-  num_total_ += 1;
-  sum_total_ += value;
-  sum_squares_total_ += value * value;
+  total_append_perf_counter_.AddTiming(clock_->NowMicros() - before);
   return s;
 }
 
@@ -287,15 +280,37 @@ Status ZNSWAL::ReplayOrdered(ZNSMemTable* mem, SequenceNumber* seq) {
 }
 #endif
 
+Status ZNSWAL::Reset() {
+  uint64_t before = clock_->NowMicros();
+  Status s = FromStatus(log_.ResetAll());
+#ifdef WAL_UNORDERED
+  sequence_nr_ = 0;
+#endif
+  reset_perf_counter_.AddTiming(clock_->NowMicros() - before);
+  return s;
+}
+
+
+Status ZNSWAL::Recover() {
+  uint64_t before = clock_->NowMicros();
+  Status s = FromStatus(log_.RecoverPointers());
+  recovery_perf_counter_.AddTiming(clock_->NowMicros() - before);
+  return s;
+}
+
 Status ZNSWAL::Replay(ZNSMemTable* mem, SequenceNumber* seq) {
   Status s = Status::OK();
+  // This check is also done in both replays, but ensures we do NOT measure it for perf!!
+  if (log_.Empty()) {
+    return s;
+  }
   uint64_t before = clock_->NowMicros();
 #ifdef WAL_UNORDERED
   s = ReplayUnordered(mem, seq);
 #else
   s = ReplayOrdered(mem, seq);
 #endif
-  replay_time_ = clock_->NowMicros() - before;
+  replay_perf_counter_.AddTiming(clock_->NowMicros() - before);
   return s;
 }
 
@@ -304,132 +319,4 @@ Status ZNSWAL::Close() {
   s = MarkInactive();
   return s;
 }
-
-// Status ZNSWAL::ObsoleteDirectAppend(const Slice& data) {
-//   char buf[data.size() + 2 * sizeof(uint32_t)];
-//   std::memcpy(buf + sizeof(uint32_t), data.data(), data.size());
-//   EncodeFixed32(buf, data.size() + sizeof(uint32_t));
-//   EncodeFixed32(buf + data.size() + sizeof(uint32_t), 0);
-//   Status s =
-//       committer_.SafeCommit(Slice(buf, data.size() + 2 * sizeof(uint32_t)));
-//   // printf("Tail %lu Head %lu \n", log_.GetWriteTail(),
-//   log_.GetWriteHead()); return s;
-// }
-
-// See LevelDB env_posix. This is similar, but slightly different as we store
-// offsets and do not directly use the committed CRC format.
-// Status ZNSWAL::ObsoleteAppend(const Slice& data) {
-//   size_t write_size = data.size();
-//   const char* write_data = data.data();
-
-//   // [4 bytes for next| N bytes for entry | sentinel ...]
-//   size_t required_write_size = write_size + 2 * sizeof(uint32_t);
-//   if (pos_ + required_write_size < buffsize_) {
-//     EncodeFixed32(buf_ + pos_, pos_ + write_size + sizeof(uint32_t));
-//     std::memcpy(buf_ + pos_ + sizeof(uint32_t), write_data, write_size);
-//     pos_ += write_size + sizeof(uint32_t);
-//     EncodeFixed32(buf_ + pos_, 0);
-//     return Status::OK();
-//   }
-
-//   // Can't fit in buffer, so need to do at least one write.
-//   Status s = Sync();
-//   if (!s.ok()) {
-//     return s;
-//   }
-
-//   // Small writes go to buffer, large writes are written directly.
-//   if (pos_ + required_write_size < buffsize_) {
-//     EncodeFixed32(buf_ + pos_, pos_ + write_size + sizeof(uint32_t));
-//     std::memcpy(buf_ + pos_ + sizeof(uint32_t), write_data, write_size);
-//     pos_ += write_size + sizeof(uint32_t);
-//     EncodeFixed32(buf_ + pos_, 0);
-//     return Status::OK();
-//   }
-//   return DirectAppend(data);
-// }
-
-// Status ZNSWAL::ObsoleteSync() {
-//   Status s = Status::OK();
-//   if (pos_ > 0) {
-//     s = committer_.SafeCommit(Slice(buf_, pos_ + sizeof(uint32_t)));
-//     pos_ = 0;
-//     memset(buf_, 0, buffsize_);
-//   }
-//   return s;
-// }
-
-// Status ZNSWAL::ObsoleteReplay(ZNSMemTable* mem, SequenceNumber* seq) {
-//   Status s = Status::OK();
-//   if (log_.Empty()) {
-//     return s;
-//   }
-//   // Used for each batch
-//   WriteOptions wo;
-//   Slice record;
-//   // Iterate over all batches and apply them to the memtable
-//   ZnsCommitReader reader;
-//   // printf("Tail %lu Head %lu \n", log_.GetWriteTail(),
-//   log_.GetWriteHead()); committer_.GetCommitReader(0, log_.GetWriteTail(),
-//   log_.GetWriteHead(),
-//                              &reader);
-//   while (committer_.SeekCommitReader(reader, &record)) {
-//     uint32_t pos = sizeof(uint32_t);
-//     uint32_t upto = DecodeFixed32(record.data());
-//     if (upto > record.size()) {
-//       s = Status::Corruption();
-//       break;
-//     }
-//     uint32_t next = DecodeFixed32(record.data() + upto);
-//     do {
-//       WriteBatch batch;
-//       s = WriteBatchInternal::SetContents(
-//           &batch, Slice(record.data() + pos, upto - pos));
-//       if (!s.ok()) {
-//         break;
-//       }
-//       s = mem->Write(wo, &batch);
-//       if (!s.ok()) {
-//         break;
-//       }
-//       // Ensure the sequence number is up to date.
-//       const SequenceNumber last_seq = WriteBatchInternal::Sequence(&batch) +
-//                                       WriteBatchInternal::Count(&batch) - 1;
-//       if (last_seq > *seq) {
-//         *seq = last_seq;
-//       }
-//       pos = upto + sizeof(uint32_t);
-//       upto = next;
-//       if (upto == record.size()) {
-//         break;
-//       }
-//       if (upto > record.size()) {
-//         s = Status::Corruption();
-//         break;
-//       }
-//       if (next != 0) {
-//         next = DecodeFixed32(record.data() + next);
-//       }
-//     } while (next > upto || (next == 0 && upto != 0));
-//   }
-//   committer_.CloseCommit(reader);
-//   return s;
-// }
-
-// committer_.GetCommitReader(0, log_.GetWriteTail(), log_.GetWriteHead(),
-//                            &reader);
-// while (committer_.SeekCommitReader(reader, &record)) {
-//   uint64_t data_size = DecodeFixed64(record.data());
-//   uint64_t seq_nr = DecodeFixed64(record.data() + sizeof(uint64_t));
-//   if (data_size > record.size() - 2 * sizeof(uint64_t)) {
-//     s = Status::Corruption();
-//     break;
-//   }
-//   char* dat = new char[data_size];
-//   memcpy(dat, record.data() + 2 * sizeof(uint64_t), data_size);
-//   entries.push_back(std::make_pair(seq_nr, std::make_pair(dat,
-//   data_size)));
-// }
-// committer_.CloseCommit(reader);
-
 }  // namespace ROCKSDB_NAMESPACE

--- a/implementation/rocksdb/db/zns_impl/persistence/zns_wal.h
+++ b/implementation/rocksdb/db/zns_impl/persistence/zns_wal.h
@@ -50,25 +50,8 @@ class ZNSWAL : public RefCounter {
   Status Replay(ZNSMemTable* mem, SequenceNumber* seq);
   // Closes the WAL gracefully (sync, free buffers)
   Status Close();
-
-  inline Status Reset() {
-    uint64_t before = clock_->NowMicros();
-    Status s = FromStatus(log_.ResetAll());
-#ifdef WAL_UNORDERED
-    sequence_nr_ = 0;
-#endif
-    uint64_t value = clock_->NowMicros() - before;
-    reset_nummers_ += 1;
-    reset_time_ += value;
-    reset_time_squares_ += value * value;
-    return s;
-  }
-  inline Status Recover() {
-    uint64_t before = clock_->NowMicros();
-    Status s = FromStatus(log_.RecoverPointers());
-    recovery_time_ = clock_->NowMicros() - before;
-    return s;
-  }
+  Status Reset();
+  Status Recover();
   inline bool Empty() { return log_.Empty(); }
   inline uint64_t SpaceAvailable() const { return log_.SpaceAvailable(); }
   inline size_t SpaceNeeded(const size_t size) {
@@ -102,21 +85,11 @@ class ZNSWAL : public RefCounter {
   inline Status MarkInactive() { return FromStatus(log_.MarkInactive()); }
 
   // Timing
-  inline uint64_t TimeSpendWaitingOnStorageNumber() { return num_; }
-  inline uint64_t TimeSpendWaitingOnStorage() { return sum_; }
-  inline uint64_t TimeSpendWaitingOnStorageSquared() { return sum_squares_; }
-  inline uint64_t TimeSpendWaitingOnStorageNumberTotal() { return num_total_; }
-  inline uint64_t TimeSpendWaitingOnStorageTotal() { return sum_total_; }
-  inline uint64_t TimeSpendWaitingOnStorageSquaredTotal() {
-    return sum_squares_total_;
-  }
-  inline uint64_t TimeSpendWaitingOnResets() { return reset_time_; }
-  inline uint64_t TimeSpendWaitingOnResetsSquared() {
-    return reset_time_squares_;
-  }
-  inline uint64_t TimeSpendWaitingOnResetsNumber() { return reset_nummers_; }
-  inline uint64_t TimeSpendReplaying() { return replay_time_; }
-  inline uint64_t TimeSpendRecovering() { return recovery_time_; }
+  inline TimingCounter GetTotalAppendPerfCounter() { return total_append_perf_counter_; }
+  inline TimingCounter GetStorageAppendPerfCounter() { return storage_append_perf_counter_; }
+  inline TimingCounter GetReplayPerfCounter() { return replay_perf_counter_; }
+  inline TimingCounter GetRecoveryPerfCounter() { return recovery_perf_counter_; }
+  inline TimingCounter GetResetPerfCounter() { return reset_perf_counter_; }
 
  private:
   // references
@@ -136,24 +109,12 @@ class ZNSWAL : public RefCounter {
 
   // Timing
   SystemClock* const clock_;
-  uint64_t num_{0};
-  uint64_t sum_{0};
-  uint64_t sum_squares_{0};
-  uint64_t num_total_{0};
-  uint64_t sum_total_{0};
-  uint64_t sum_squares_total_{0};
-  uint64_t replay_time_{0};
-  uint64_t recovery_time_{0};
-  uint64_t reset_time_{0};
-  uint64_t reset_time_squares_{0};
-  uint64_t reset_nummers_{0};
+  TimingCounter storage_append_perf_counter_;
+  TimingCounter total_append_perf_counter_;
+  TimingCounter replay_perf_counter_;
+  TimingCounter recovery_perf_counter_;
+  TimingCounter reset_perf_counter_;
 };
 }  // namespace ROCKSDB_NAMESPACE
 #endif
 #endif
-
-// OBSOLETE, uses memory buffer, which we do not want
-// Status ObsoleteDirectAppend(const Slice& data);
-// Status ObsoleteAppend(const Slice& data);
-// Status ObsoleteSync();
-// Status ObsoleteReplay(ZNSMemTable* mem, SequenceNumber* seq);

--- a/implementation/rocksdb/db/zns_impl/persistence/zns_wal_manager.h
+++ b/implementation/rocksdb/db/zns_impl/persistence/zns_wal_manager.h
@@ -33,7 +33,7 @@ class ZnsWALManager : public RefCounter {
   Status Recover(ZNSMemTable* mem, SequenceNumber* seq);
 
   std::vector<ZNSDiagnostics> IODiagnostics();
-  void PrintAdditionalWALStatistics();
+  std::vector<std::pair<std::string, const TimingCounter>> GetAdditionalWALStatistics();
 
  private:
   std::array<ZNSWAL*, N> wals_;

--- a/implementation/rocksdb/docs/Gemfile.lock
+++ b/implementation/rocksdb/docs/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
We need to be able to measure the latency of individual background operations.
To do this, we need to have a breakdown of the operations themselves. From beginning to end.
What is added:
- Generic counter for performance (min, max, avg, stdef, sum, number of ops)
- WAL now uses the generic counters for performance
- Add counters for flushes, L0 compaction and LN compaction
- Improve performance printing at the end (prettier., more readable and accurate)
- Move diagnostics to `db_impl_zns_diagnostics.cc`
- Repair Linting tools and lint files