### PR TITLE
Fix wal perf test

### DIFF
--- a/implementation/rocksdb/db/tropodb/impl/tropodb_impl_client.cc
+++ b/implementation/rocksdb/db/tropodb/impl/tropodb_impl_client.cc
@@ -80,7 +80,7 @@ Status TropoDBImpl::MakeRoomForWrite(size_t size, uint8_t parallel_number) {
                                               max_write_buffer_size_);
       mem_[parallel_number]->Ref();
       FlushData* dat = new FlushData(this, parallel_number);
-      env_->Schedule(&TropoDBImpl::BGFlushWork, this, rocksdb::Env::HIGH);
+      env_->Schedule(&TropoDBImpl::BGFlushWork, dat, rocksdb::Env::HIGH);
 #else
       // Switch to fresh memtable
       imm_[parallel_number] = mem_[parallel_number];

--- a/implementation/rocksdb/db/tropodb/impl/tropodb_impl_client.cc
+++ b/implementation/rocksdb/db/tropodb/impl/tropodb_impl_client.cc
@@ -79,6 +79,7 @@ Status TropoDBImpl::MakeRoomForWrite(size_t size, uint8_t parallel_number) {
       mem_[parallel_number] = new TropoMemtable(options_, internal_comparator_,
                                               max_write_buffer_size_);
       mem_[parallel_number]->Ref();
+      FlushData* dat = new FlushData(this, parallel_number);
       env_->Schedule(&TropoDBImpl::BGFlushWork, this, rocksdb::Env::HIGH);
 #else
       // Switch to fresh memtable


### PR DESCRIPTION
WALPerfTest uses the wrong data type for scheduling flushes and will segfault.
Solve the issue by using the correct datatype.